### PR TITLE
preserve ordering when destructuring json patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,7 @@ version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -275,7 +276,7 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "toml-editor"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "toml-editor"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 toml_edit = "0.14.4"
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 serde = { version = "1.0", features = ["derive"] }
 clap = { version = "3.2.10", features = ["derive"] }
 anyhow = "1.0.58"

--- a/src/adder.rs
+++ b/src/adder.rs
@@ -17,7 +17,7 @@ pub fn handle_add(field: &str, value: &str, doc: &mut Document) -> Result<()> {
         get_field(&path_split, &last_field, DoInsert::Yes, doc).context("Could not find field")?;
 
     let field_value_json: JValue =
-        from_str(&value).context("parsing value field in add request")?;
+        from_str(value).context("parsing value field in add request")?;
 
     let is_inline = matches!(
         final_field_value,
@@ -352,6 +352,112 @@ hi = 123
 
 [[foo]]
 hi = 1234
+"#
+    );
+
+    add_test!(
+        preserve_ordering_on_unrelated_field,
+        "run",
+        r#""echo heyo""#,
+        r#"
+run = "echo hi"
+
+[env]
+VIRTUAL_ENV = "/home/runner/${REPL_SLUG}/venv"
+PATH = "${VIRTUAL_ENV}/bin"
+PYTHONPATH="${VIRTUAL_ENV}/lib/python3.8/site-packages"
+REPLIT_POETRY_PYPI_REPOSITORY="https://package-proxy.replit.com/pypi/"
+MPLBACKEND="TkAgg"
+POETRY_CACHE_DIR="${HOME}/${REPL_SLUG}/.cache/pypoetry"
+"#
+        .parse::<Document>()
+        .unwrap(),
+        r#"
+run = "echo heyo"
+
+[env]
+VIRTUAL_ENV = "/home/runner/${REPL_SLUG}/venv"
+PATH = "${VIRTUAL_ENV}/bin"
+PYTHONPATH="${VIRTUAL_ENV}/lib/python3.8/site-packages"
+REPLIT_POETRY_PYPI_REPOSITORY="https://package-proxy.replit.com/pypi/"
+MPLBACKEND="TkAgg"
+POETRY_CACHE_DIR="${HOME}/${REPL_SLUG}/.cache/pypoetry"
+"#
+    );
+
+    add_test!(
+        preserve_ordering_on_semi_related_field,
+        "env/TEST",
+        r#""heyo""#,
+        r#"
+[env]
+VIRTUAL_ENV = "/home/runner/${REPL_SLUG}/venv"
+PATH = "${VIRTUAL_ENV}/bin"
+PYTHONPATH="${VIRTUAL_ENV}/lib/python3.8/site-packages"
+REPLIT_POETRY_PYPI_REPOSITORY="https://package-proxy.replit.com/pypi/"
+MPLBACKEND="TkAgg"
+POETRY_CACHE_DIR="${HOME}/${REPL_SLUG}/.cache/pypoetry"
+"#
+        .parse::<Document>()
+        .unwrap(),
+        r#"
+[env]
+VIRTUAL_ENV = "/home/runner/${REPL_SLUG}/venv"
+PATH = "${VIRTUAL_ENV}/bin"
+PYTHONPATH="${VIRTUAL_ENV}/lib/python3.8/site-packages"
+REPLIT_POETRY_PYPI_REPOSITORY="https://package-proxy.replit.com/pypi/"
+MPLBACKEND="TkAgg"
+POETRY_CACHE_DIR="${HOME}/${REPL_SLUG}/.cache/pypoetry"
+TEST = "heyo"
+"#
+    );
+
+    add_test!(
+        preserve_ordering_on_related_field,
+        "env/PATH",
+        r#""${VIRTUAL_ENV}/bin""#,
+        r#"
+[env]
+VIRTUAL_ENV = "/home/runner/${REPL_SLUG}/venv"
+PATH = "${VIRTUAL_ENV}/bin"
+PYTHONPATH="${VIRTUAL_ENV}/lib/python3.8/site-packages"
+REPLIT_POETRY_PYPI_REPOSITORY="https://package-proxy.replit.com/pypi/"
+MPLBACKEND="TkAgg"
+POETRY_CACHE_DIR="${HOME}/${REPL_SLUG}/.cache/pypoetry"
+"#
+        .parse::<Document>()
+        .unwrap(),
+        r#"
+[env]
+VIRTUAL_ENV = "/home/runner/${REPL_SLUG}/venv"
+PATH = "${VIRTUAL_ENV}/bin"
+PYTHONPATH="${VIRTUAL_ENV}/lib/python3.8/site-packages"
+REPLIT_POETRY_PYPI_REPOSITORY="https://package-proxy.replit.com/pypi/"
+MPLBACKEND="TkAgg"
+POETRY_CACHE_DIR="${HOME}/${REPL_SLUG}/.cache/pypoetry"
+"#
+    );
+
+    add_test!(
+        preserve_ordering_on_add_object,
+        "env",
+        r#"{"VIRTUAL_ENV":"/home/runner/${REPL_SLUG}/venv","PATH":"${VIRTUAL_ENV}/bin","PYTHONPATH":"${VIRTUAL_ENV}/lib/python3.8/site-packages","REPLIT_POETRY_PYPI_REPOSITORY":"https://package-proxy.replit.com/pypi/","MPLBACKEND":"TkAgg","POETRY_CACHE_DIR":"${HOME}/${REPL_SLUG}/.cache/pypoetry"}
+"#,
+        r#"
+run = "hi"
+"#
+        .parse::<Document>()
+        .unwrap(),
+        r#"
+run = "hi"
+
+[env]
+VIRTUAL_ENV = "/home/runner/${REPL_SLUG}/venv"
+PATH = "${VIRTUAL_ENV}/bin"
+PYTHONPATH = "${VIRTUAL_ENV}/lib/python3.8/site-packages"
+REPLIT_POETRY_PYPI_REPOSITORY = "https://package-proxy.replit.com/pypi/"
+MPLBACKEND = "TkAgg"
+POETRY_CACHE_DIR = "${HOME}/${REPL_SLUG}/.cache/pypoetry"
 "#
     );
 }

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -156,7 +156,7 @@ mod converter_tests {
         let res = toml.to_string();
         assert_eq!(
             res.trim(),
-            "{ arr = [{ a = 1, b = 2 }, { a = 3, b = 4 }], who = 123 }".trim()
+            "{ who = 123, arr = [{ a = 1, b = 2 }, { a = 3, b = 4 }] }".trim()
         );
     }
 


### PR DESCRIPTION
https://replit.slack.com/archives/C03SHP0HB7Z/p1660056306191389
From the earlier incident, we realised that ordering was not preserved when modifying env vars for the .replit. 
This was because when parsing the json sent through the service, the ordering was not preserved. To preserve the ordering, we just need to enable the `preserve_order` feature flag in serde_json.

I also included several tests to check that everything works.