### PR TITLE
nix: add devshell, add formatter, remove flake-utils

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,0 @@
-# flake-compat makes Nix flakes compatible with the old Nix cli commands, like nix-build and nix-shell.
-(import (
-  fetchTarball {
-    url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
-    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2"; }
-) {
-  src =  ./.;
-}).defaultNix
-

--- a/flake.lock
+++ b/flake.lock
@@ -1,20 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "locked": {
-        "lastModified": 1656065134,
-        "narHash": "sha256-oc6E6ByIw3oJaIyc67maaFcnjYOz1mMcOtHxbEf9NwQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "bee6a7250dd1b01844a2de7e02e4df7d8a0a206c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1656401090,
@@ -33,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,25 +1,34 @@
 {
   description = "A toml editor that preserves formatting.";
 
-  inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
-  };
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem
-      (system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-          toml-editor = pkgs.callPackage ./toml-editor.nix {
-            rev = if self ? rev then "0.0.0-${builtins.substring 0 7 self.rev}" else "0.0.0-dirty";
-          };
-        in
-        {
-          defaultPackage = toml-editor;
-          packages = {
-            inherit toml-editor;
-          };
-        }
-      );
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    systems = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+    eachSystem = nixpkgs.lib.genAttrs systems;
+    rev =
+      if self ? rev
+      then "0.0.0-${builtins.substring 0 7 self.rev}"
+      else "0.0.0-dirty";
+  in {
+    packages = eachSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+    in rec {
+      default = toml-editor;
+      toml-editor = pkgs.callPackage ./toml-editor.nix {
+        inherit rev;
+      };
+      devShell = pkgs.callPackage ./nix/devshell {};
+      fmt = pkgs.callPackage ./nix/fmt {};
+    });
+    formatter = eachSystem (system: self.packages.${system}.fmt);
+  };
 }

--- a/nix/devshell/default.nix
+++ b/nix/devshell/default.nix
@@ -1,0 +1,12 @@
+{
+  rustc,
+  rustfmt,
+  mkShell,
+}:
+mkShell {
+  name = "nix-editor";
+  packages = [
+    rustc
+    rustfmt
+  ];
+}

--- a/nix/fmt/default.nix
+++ b/nix/fmt/default.nix
@@ -1,0 +1,12 @@
+{
+  writeScriptBin,
+  alejandra,
+  rustfmt,
+}:
+writeScriptBin "fmt" ''
+  echo "Formatting Nix code..."
+  ${alejandra}/bin/alejandra -q .
+  echo "Formatting Rust code..."
+  PATH=$PATH:${rustfmt}/bin
+  ${rustfmt}/bin/cargo-fmt
+''

--- a/toml-editor.nix
+++ b/toml-editor.nix
@@ -1,13 +1,14 @@
-{ rustPlatform, rev }:
-
+{
+  rustPlatform,
+  rev,
+}:
 rustPlatform.buildRustPackage {
-    pname = "toml-editor";
-    version = rev;
+  pname = "toml-editor";
+  version = rev;
 
-    cargoLock = {
-      lockFile = ./Cargo.lock;
-    };
+  cargoLock = {
+    lockFile = ./Cargo.lock;
+  };
 
-    src = ./.;
+  src = ./.;
 }
-


### PR DESCRIPTION
Why
===
* cleaning up the Nix stuff and making it match nix-editor

What changed
===
* added nix formatter so nix fmt works
* removed flake-utils input in favor of genAttrs
* add devshell for nix develop

Test plan
===
* nix develop works
* nix fmt works
* nix build works