### PR TITLE
if .replit is not present, start with an empty one

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -93,7 +93,8 @@ fn do_edits(dotreplit_filepath: &Path, msg: &str, return_output: bool) -> Result
     // file and so we need to make sure we have the most up to date version.
     let dotreplit_contents = match fs::read_to_string(&dotreplit_filepath) {
         Ok(contents) => contents,
-        Err(_) => "".to_string(), // if .replit doesn't exist start with an empty one
+        Err(err) if err.kind() == io::ErrorKind::NotFound => "".to_string, // if .replit doesn't exist start with an empty one
+        Err(_) => return Err(anyhow!("error: reading file - {:?}", &dotreplit_filepath)),
     };
 
     let mut doc = dotreplit_contents

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,8 +91,10 @@ fn do_edits(dotreplit_filepath: &Path, msg: &str, return_output: bool) -> Result
 
     // we need to re-read the file each time since the user might manually edit the
     // file and so we need to make sure we have the most up to date version.
-    let dotreplit_contents = fs::read_to_string(&dotreplit_filepath)
-        .with_context(|| format!("error: reading file - {:?}", &dotreplit_filepath))?;
+    let dotreplit_contents = match fs::read_to_string(&dotreplit_filepath) {
+        Ok(contents) => contents,
+        Err(_) => "".to_string(), // if .replit doesn't exist start with an empty one
+    };
 
     let mut doc = dotreplit_contents
         .parse::<Document>()

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::{io, io::prelude::*};
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 use serde_json::from_str;
@@ -93,7 +93,7 @@ fn do_edits(dotreplit_filepath: &Path, msg: &str, return_output: bool) -> Result
     // file and so we need to make sure we have the most up to date version.
     let dotreplit_contents = match fs::read_to_string(&dotreplit_filepath) {
         Ok(contents) => contents,
-        Err(err) if err.kind() == io::ErrorKind::NotFound => "".to_string, // if .replit doesn't exist start with an empty one
+        Err(err) if err.kind() == io::ErrorKind::NotFound => "".to_string(), // if .replit doesn't exist start with an empty one
         Err(_) => return Err(anyhow!("error: reading file - {:?}", &dotreplit_filepath)),
     };
 


### PR DESCRIPTION
Why
===
* We'd like the toml-editor to work even if there is no .replit file in the project

What changed
===
* When we fail to read .replit, consider it to be an empty file and proceed like it was empty

Test plan
===
* confirm no .replit file exists
* cargo run -- --path=.replit
* `[{"op":"add", "path":"modules", "value":"[\"a\",\"b\"]"}]`
* confirm .replit file has the expected entry