### PR TITLE
Upgraded toml-edit to version 0.22.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,12 +32,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bytes"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
-
-[[package]]
 name = "clap"
 version = "3.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,7 +41,7 @@ dependencies = [
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
+ "indexmap 1.8.2",
  "once_cell",
  "strsim",
  "termcolor",
@@ -77,26 +71,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "combine"
-version = "4.6.4"
+name = "equivalent"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a604e93b79d1808327a6fca85a6f2d69de66461e7620f5a4cbf5fb4d1d7c948"
-dependencies = [
- "bytes",
- "memchr",
-]
-
-[[package]]
-name = "either"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heck"
@@ -120,16 +110,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
-name = "itertools"
-version = "0.10.3"
+name = "indexmap"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
- "either",
+ "equivalent",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -236,7 +227,7 @@ version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
- "indexmap",
+ "indexmap 1.8.2",
  "itoa",
  "ryu",
  "serde",
@@ -286,14 +277,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.14.4"
+name = "toml_datetime"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18769cd1cec395d70860ceb4d932812a0b4d06b1a4bb336745a4d21b9496e992"
 dependencies = [
- "combine",
- "indexmap",
- "itertools",
+ "indexmap 2.2.5",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -338,3 +335,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winnow"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-toml_edit = "0.14.4"
+toml_edit = "0.22.7"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde = { version = "1.0", features = ["derive"] }
 clap = { version = "3.2.10", features = ["derive"] }

--- a/src/adder.rs
+++ b/src/adder.rs
@@ -1,11 +1,11 @@
 use anyhow::{bail, Context, Result};
 use serde_json::{from_str, Value as JValue};
-use toml_edit::{Array, ArrayOfTables, Document, InlineTable, Item, Table, Value};
+use toml_edit::{Array, ArrayOfTables, DocumentMut, InlineTable, Item, Table, Value};
 
 use crate::converter::json_to_toml;
 use crate::field_finder::{get_field, DoInsert, TomlValue};
 
-pub fn handle_add(field: &str, value: &str, doc: &mut Document) -> Result<()> {
+pub fn handle_add(field: &str, value: &str, doc: &mut DocumentMut) -> Result<()> {
     let mut path_split = field
         .split('/')
         .map(|s| s.to_string())
@@ -111,9 +111,9 @@ fn add_in_generic_value(generic_value: &mut Value, last_field: &str, toml: Item)
 #[cfg(test)]
 mod adder_tests {
     use super::*;
-    use toml_edit::{Document, TomlError};
+    use toml_edit::{DocumentMut, TomlError};
 
-    fn get_dotreplit_content_with_formatting() -> Result<Document, TomlError> {
+    fn get_dotreplit_content_with_formatting() -> Result<DocumentMut, TomlError> {
         r#"test = "yo"
 [foo]
   bar = "baz"  # comment
@@ -131,7 +131,7 @@ mod adder_tests {
 [[foo.arr]]
         none = "all""#
             .to_string()
-            .parse::<Document>()
+            .parse::<DocumentMut>()
     }
 
     macro_rules! add_test {
@@ -270,7 +270,7 @@ foo = [1, 2, 3]
         simple_push_into_array,
         "arr/2",
         "123",
-        r#"arr = [1, 2]"#.parse::<Document>().unwrap(),
+        r#"arr = [1, 2]"#.parse::<DocumentMut>().unwrap(),
         r#"arr = [1, 2, 123]"#
     );
 
@@ -305,7 +305,7 @@ test = "yo"
         add_as_you_traverse,
         "foo/arr",
         r#""yup""#,
-        r#"meep = "nope""#.parse::<Document>().unwrap(),
+        r#"meep = "nope""#.parse::<DocumentMut>().unwrap(),
         r#"meep = "nope"
 
 [foo]
@@ -316,7 +316,7 @@ arr = "yup""#
         add_array_objects_deep,
         "foo/0/hi",
         r#"123"#,
-        r#"top = "hi""#.parse::<Document>().unwrap(),
+        r#"top = "hi""#.parse::<DocumentMut>().unwrap(),
         r#"top = "hi"
 
 [[foo]]
@@ -328,7 +328,7 @@ hi = 123
         add_array_objects,
         "foo/0",
         r#"{"hi": 123}"#,
-        r#"top = "hi""#.parse::<Document>().unwrap(),
+        r#"top = "hi""#.parse::<DocumentMut>().unwrap(),
         r#"top = "hi"
 
 [[foo]]
@@ -343,7 +343,7 @@ hi = 123
         r#"top = "hi"
 [[foo]]
 hi = 123"#
-            .parse::<Document>()
+            .parse::<DocumentMut>()
             .unwrap(),
         r#"top = "hi"
 [[foo]]
@@ -369,7 +369,7 @@ REPLIT_POETRY_PYPI_REPOSITORY="https://package-proxy.replit.com/pypi/"
 MPLBACKEND="TkAgg"
 POETRY_CACHE_DIR="${HOME}/${REPL_SLUG}/.cache/pypoetry"
 "#
-        .parse::<Document>()
+        .parse::<DocumentMut>()
         .unwrap(),
         r#"
 run = "echo heyo"
@@ -397,7 +397,7 @@ REPLIT_POETRY_PYPI_REPOSITORY="https://package-proxy.replit.com/pypi/"
 MPLBACKEND="TkAgg"
 POETRY_CACHE_DIR="${HOME}/${REPL_SLUG}/.cache/pypoetry"
 "#
-        .parse::<Document>()
+        .parse::<DocumentMut>()
         .unwrap(),
         r#"
 [env]
@@ -424,7 +424,7 @@ REPLIT_POETRY_PYPI_REPOSITORY="https://package-proxy.replit.com/pypi/"
 MPLBACKEND="TkAgg"
 POETRY_CACHE_DIR="${HOME}/${REPL_SLUG}/.cache/pypoetry"
 "#
-        .parse::<Document>()
+        .parse::<DocumentMut>()
         .unwrap(),
         r#"
 [env]
@@ -445,7 +445,7 @@ POETRY_CACHE_DIR="${HOME}/${REPL_SLUG}/.cache/pypoetry"
         r#"
 run = "hi"
 "#
-        .parse::<Document>()
+        .parse::<DocumentMut>()
         .unwrap(),
         r#"
 run = "hi"

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -116,7 +116,7 @@ fn create_toml_array_of_tables(items: Vec<Item>) -> Result<Item> {
 mod converter_tests {
     use super::*;
     use serde_json::{from_str, Value as JValue};
-    use toml_edit::Document;
+    use toml_edit::DocumentMut;
 
     #[test]
     fn test_json_to_toml_array() {
@@ -169,7 +169,7 @@ mod converter_tests {
         let json: JValue = from_str(json_string).unwrap();
         let toml_res = json_to_toml(&json, false);
         assert!(toml_res.is_ok());
-        let mut doc = Document::new();
+        let mut doc = DocumentMut::new();
         doc["arr"] = toml_res.unwrap();
 
         let expected = r#"
@@ -194,7 +194,7 @@ b = 4
         let json: JValue = from_str(json_string).unwrap();
         let toml_res = json_to_toml(&json, false);
         assert!(toml_res.is_ok());
-        let mut doc = Document::new();
+        let mut doc = DocumentMut::new();
         doc["arr"] = toml_res.unwrap();
 
         let expected = r#"

--- a/src/field_finder.rs
+++ b/src/field_finder.rs
@@ -1,7 +1,7 @@
 use std::{io::Error, io::ErrorKind};
 
 use anyhow::{bail, Context, Result};
-use toml_edit::{Array, ArrayOfTables, Document, InlineTable, Item, Table, Value};
+use toml_edit::{Array, ArrayOfTables, DocumentMut, InlineTable, Item, Table, Value};
 
 pub enum TomlValue<'a> {
     Table(&'a mut Table),
@@ -21,7 +21,7 @@ pub fn get_field<'a>(
     path: &[String],
     last_field: &String,
     do_insert: DoInsert,
-    doc: &'a mut Document,
+    doc: &'a mut DocumentMut,
 ) -> Result<TomlValue<'a>> {
     let current_table = doc.as_table_mut();
 
@@ -192,7 +192,7 @@ fn descend_array<'a>(
 #[cfg(test)]
 mod finger_tests {
     use super::*;
-    use toml_edit::Document;
+    use toml_edit::DocumentMut;
 
     #[test]
     fn get_basic_field() {
@@ -204,7 +204,7 @@ bar = "baz"
 bla = "bla"
 "#;
 
-        let mut doc = doc_string.parse::<Document>().unwrap();
+        let mut doc = doc_string.parse::<DocumentMut>().unwrap();
         let val = get_field(
             &(vec!["foo".to_string()]),
             &"bar".to_string(),
@@ -223,7 +223,7 @@ bla = "bla"
     #[test]
     fn insert_inline_array() {
         let doc_string = r#"test = [ 1 ]"#;
-        let mut doc = doc_string.parse::<Document>().unwrap();
+        let mut doc = doc_string.parse::<DocumentMut>().unwrap();
         let fields = ["test".to_string()];
         let val = get_field(&(fields), &"1".to_string(), DoInsert::Yes, &mut doc).unwrap();
 
@@ -242,7 +242,7 @@ foo = "bar"
 [[test]]
 foo = "baz"
 "#;
-        let mut doc = doc_string.parse::<Document>().unwrap();
+        let mut doc = doc_string.parse::<DocumentMut>().unwrap();
         let fields = ["test".to_string()];
         let val = get_field(&(fields), &"2".to_string(), DoInsert::Yes, &mut doc).unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use anyhow::{anyhow, Context, Result};
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 use serde_json::from_str;
-use toml_edit::Document;
+use toml_edit::DocumentMut;
 
 use crate::adder::handle_add;
 use crate::remover::handle_remove;
@@ -98,7 +98,7 @@ fn do_edits(dotreplit_filepath: &Path, msg: &str, return_output: bool) -> Result
     };
 
     let mut doc = dotreplit_contents
-        .parse::<Document>()
+        .parse::<DocumentMut>()
         .with_context(|| format!("error: parsing file - {:?}", &dotreplit_filepath))?;
 
     for op in json {

--- a/src/remover.rs
+++ b/src/remover.rs
@@ -1,11 +1,11 @@
 use std::{io::Error, io::ErrorKind};
 
 use anyhow::{bail, Context, Result};
-use toml_edit::{Array, ArrayOfTables, Document, InlineTable, Table};
+use toml_edit::{Array, ArrayOfTables, DocumentMut, InlineTable, Table};
 
 use crate::field_finder::{get_field, DoInsert, TomlValue};
 
-pub fn handle_remove(field: &str, doc: &mut Document) -> Result<()> {
+pub fn handle_remove(field: &str, doc: &mut DocumentMut) -> Result<()> {
     let mut path_split = field
         .split('/')
         .map(|s| s.to_string())
@@ -67,9 +67,9 @@ fn remove_in_inline_table(inline_table: &mut InlineTable, last_field: &str) -> R
 #[cfg(test)]
 mod remover_tests {
     use super::*;
-    use toml_edit::{Document, TomlError};
+    use toml_edit::{DocumentMut, TomlError};
 
-    fn get_dotreplit_content() -> Result<Document, TomlError> {
+    fn get_dotreplit_content() -> Result<DocumentMut, TomlError> {
         r#"test = "yo"
 [foo]
 bar = "baz"
@@ -82,10 +82,10 @@ glub = "group"
 [[foo.arr]]
 none = "all""#
             .to_string()
-            .parse::<Document>()
+            .parse::<DocumentMut>()
     }
 
-    fn get_dotreplit_content_with_formatting() -> Result<Document, TomlError> {
+    fn get_dotreplit_content_with_formatting() -> Result<DocumentMut, TomlError> {
         r#"test = "yo"
 [foo]
   bar = "baz"  # comment
@@ -101,7 +101,7 @@ none = "all""#
 [[foo.arr]]
         none = "all""#
             .to_string()
-            .parse::<Document>()
+            .parse::<DocumentMut>()
     }
 
     macro_rules! remove_test {
@@ -193,7 +193,7 @@ glub = "group"
     remove_test!(
         test_remove_inline_array,
         "arr/1",
-        "arr = [1, 2, 3, 4] # comment".parse::<Document>().unwrap(),
+        "arr = [1, 2, 3, 4] # comment".parse::<DocumentMut>().unwrap(),
         "arr = [1, 3, 4] # comment"
     );
 
@@ -201,7 +201,7 @@ glub = "group"
         test_remove_inline_table,
         "tbl/bla",
         "tbl = { bla = \"bar\", blue = 123 } # go go"
-            .parse::<Document>()
+            .parse::<DocumentMut>()
             .unwrap(),
         "tbl = { blue = 123 } # go go"
     );
@@ -211,7 +211,7 @@ glub = "group"
         "foo/bar/baz/boop",
         "[foo]
         yup = 123"
-            .parse::<Document>()
+            .parse::<DocumentMut>()
             .unwrap(),
         "[foo]
         yup = 123"


### PR DESCRIPTION
# Why?

Upgrade toml-edit to prep for some more changes using its API.

## Changes

1. Updated the version
2. Fixed type errors/warnings

## Test

1. cargo test still green.