### PR TITLE
feat/Get operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 result
 
 .replit
+.cargo/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,72 +3,104 @@
 version = 3
 
 [[package]]
+name = "anstream"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
+name = "clap"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
+ "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
+name = "clap_builder"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "clap"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
- "atty",
- "bitflags",
- "clap_derive",
+ "anstream",
+ "anstyle",
  "clap_lex",
- "indexmap 1.9.3",
- "once_cell",
  "strsim",
- "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.25"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "equivalent"
@@ -78,40 +110,15 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
@@ -120,7 +127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -130,52 +137,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
-name = "libc"
-version = "0.2.153"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
-
-[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
-
-[[package]]
-name = "once_cell"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -218,7 +183,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -227,7 +192,7 @@ version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -235,20 +200,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "syn"
@@ -260,21 +214,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "toml-editor"
@@ -299,7 +238,7 @@ version = "0.22.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
 dependencies = [
- "indexmap 2.2.5",
+ "indexmap",
  "toml_datetime",
  "winnow",
 ]
@@ -311,41 +250,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
-name = "version_check"
-version = "0.9.4"
+name = "utf8parse"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
+name = "windows-sys"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
+ "windows-targets",
 ]
 
 [[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
+name = "windows-targets"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "winapi",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
+name = "windows_aarch64_gnullvm"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.58"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "atty"
@@ -33,15 +33,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "clap"
-version = "3.2.12"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8b79fe3946ceb4a0b1c080b4018992b8d27e9ff363644c1c9b6387c854614d"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap 1.8.2",
+ "indexmap 1.9.3",
  "once_cell",
  "strsim",
  "termcolor",
@@ -50,15 +50,15 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.7"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
+checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -78,9 +78,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -90,9 +90,9 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -105,12 +105,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown 0.11.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -125,33 +125,33 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.1.0"
+version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "proc-macro-error"
@@ -162,7 +162,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -179,55 +179,55 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.10"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
- "indexmap 1.8.2",
+ "indexmap 2.2.5",
  "itoa",
  "ryu",
  "serde",
@@ -241,9 +241,20 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.96"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -252,18 +263,18 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "textwrap"
-version = "0.15.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "toml-editor"
@@ -284,9 +295,9 @@ checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.7"
+version = "0.22.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18769cd1cec395d70860ceb4d932812a0b4d06b1a4bb336745a4d21b9496e992"
+checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
 dependencies = [
  "indexmap 2.2.5",
  "toml_datetime",
@@ -295,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "version_check"
@@ -323,9 +334,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ edition = "2018"
 toml_edit = "0.22.7"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde = { version = "1.0", features = ["derive"] }
-clap = { version = "3.2.10", features = ["derive"] }
+clap = { version = "4.5.4", features = ["derive"] }
 anyhow = "1.0.58"

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,8 +126,11 @@ fn do_edits(
                 outputs.push(json!("ok"));
             }
             OpKind::Get => match traversal::traverse(TraverseOps::Get, &mut doc, &path) {
-                Ok(value) => outputs.push(value),
-                Err(error) => outputs.push(Value::Null),
+                Ok(value) => outputs.push(value.unwrap_or_default()),
+                Err(error) => {
+                    eprintln!("Error processing {}: {}", path, error);
+                    outputs.push(Value::Null)
+                }
             },
             OpKind::Remove => {
                 changed = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,7 +125,7 @@ fn do_edits(
                 handle_add(&path, &value, &mut doc)?
             }
             OpKind::Get => {
-                let value = traversal::traverse(&path, &mut doc, TraverseOps::Get)?;
+                let value = traversal::traverse(TraverseOps::Get, &mut doc, &path)?;
                 outputs.push(value);
             }
             OpKind::Remove => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use toml_edit::DocumentMut;
 
 use crate::adder::handle_add;
 use crate::remover::handle_remove;
+use crate::traversal::TraverseOps;
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -124,8 +125,7 @@ fn do_edits(
                 handle_add(&path, &value, &mut doc)?
             }
             OpKind::Get => {
-                let op = traversal::TraverseOps::Get(Box::new(|val| val.to_value()));
-                let value = traversal::traverse(&path, &mut doc, op)?;
+                let value = traversal::traverse(&path, &mut doc, TraverseOps::Get)?;
                 outputs.push(value);
             }
             OpKind::Remove => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,7 @@ fn do_edits(
                 handle_add(&path, &value, &mut doc)?
             }
             OpKind::Get => {
-                let op = traversal::TraverseOps::Get(Box::new(|val| println!("{}", val)));
+                let op = traversal::TraverseOps::Get(Box::new(|val| val.to_value()));
                 let value = traversal::traverse(&path, &mut doc, op)?;
                 outputs.push(value);
             }

--- a/src/remover.rs
+++ b/src/remover.rs
@@ -193,7 +193,9 @@ glub = "group"
     remove_test!(
         test_remove_inline_array,
         "arr/1",
-        "arr = [1, 2, 3, 4] # comment".parse::<DocumentMut>().unwrap(),
+        "arr = [1, 2, 3, 4] # comment"
+            .parse::<DocumentMut>()
+            .unwrap(),
         "arr = [1, 3, 4] # comment"
     );
 

--- a/src/traversal.rs
+++ b/src/traversal.rs
@@ -83,6 +83,12 @@ impl At<'_> {
             }
             At::Value(value) => match value {
                 Value::Array(arr) => At::Array(arr).fold(key, path, op),
+                Value::InlineTable(table) => {
+                    let mut found = table
+                        .get_mut(key)
+                        .ok_or(anyhow!("Unable to index table with {:?}", key))?;
+                    do_traverse(path, &mut At::Value(&mut found), op)
+                }
                 _ => Err(anyhow!("Unable to index value {:?} with {:?}", value, key)),
             },
         }

--- a/src/traversal.rs
+++ b/src/traversal.rs
@@ -13,7 +13,7 @@ pub enum At<'a> {
 }
 
 pub enum TraverseOps {
-    Get(Box<dyn FnOnce(&mut At) -> Result<Json>>),
+    Get,
 }
 
 /*
@@ -42,7 +42,7 @@ fn do_traverse(path: &[&str], item: &mut At, op: TraverseOps) -> Result<Json> {
     }
 
     match op {
-        TraverseOps::Get(callback) => callback(item),
+        TraverseOps::Get => item.to_value(),
     }
 }
 

--- a/src/traversal.rs
+++ b/src/traversal.rs
@@ -1,24 +1,135 @@
 use anyhow::{anyhow, Result};
+use serde_json::Map;
 use serde_json::Value as Json;
-use toml_edit::{DocumentMut, Item};
+use toml_edit::{Array, ArrayOfTables, DocumentMut, Item, Table, Value};
 
-pub enum TraverseOps {
-    Get(Box<dyn FnOnce(serde_json::Value) -> ()>),
+#[derive(Debug)]
+pub enum At<'a> {
+    Array(&'a mut Array),
+    ArrayOfTables(&'a mut ArrayOfTables),
+    Item(&'a mut Item),
+    Table(&'a mut Table),
+    Value(&'a mut Value),
 }
 
-pub fn traverse(field: &str, doc: &mut DocumentMut, op: TraverseOps) -> Result<Json> {
-    let path_split = field
-        .split('/')
-        .map(|s| s.to_string())
-        .collect::<Vec<String>>();
+pub enum TraverseOps {
+    Get(Box<dyn FnOnce(&mut At) -> Result<Json>>),
+}
+
+/*
+array:           Type representing a TOML array, payload of `Value::Array`
+array_of_tables: Type representing a TOML array of tables
+item:            Type representing either a value, a table, an array of tables, or none.
+table:           Type representing a TOML non-inline table
+value:           Representation of a TOML Value (as part of a Key/Value Pair).
+
+*/
+
+pub fn traverse<'a>(field: &str, doc: &'a mut DocumentMut, op: TraverseOps) -> Result<Json> {
+    let path_split = field.split('/').collect::<Vec<&str>>();
+    let path_slice = path_split.as_slice();
     let root_key = path_split.get(0).ok_or(anyhow!("Invalid query path!"))?;
     let table = doc.as_table_mut();
     let item = table
         .get_mut(root_key)
         .ok_or(anyhow!("Missing table for traversal"))?;
-    do_traverse(path_split, item, op)
+    do_traverse(&path_slice[1..], &mut At::Item::<'a>(item), op)
 }
 
-fn do_traverse(mut path: Vec<String>, item: &mut Item, op: TraverseOps) -> Result<Json> {
-    Ok(Json::Null)
+fn do_traverse(path: &[&str], item: &mut At, op: TraverseOps) -> Result<Json> {
+    if !path.is_empty() {
+        return item.fold(path[0], &path[1..], op);
+    }
+
+    match op {
+        TraverseOps::Get(callback) => callback(item),
+    }
+}
+
+impl At<'_> {
+    fn fold(&mut self, key: &str, path: &[&str], op: TraverseOps) -> Result<Json> {
+        match self {
+            At::Array(arr) => {
+                let index = key
+                    .parse::<usize>()
+                    .map_err(|_| anyhow!("Key is not a valid integer"))?;
+                let member = arr.get_mut(index).ok_or(anyhow!("Array out of range"))?;
+                do_traverse(path, &mut At::Value(member), op)
+            }
+            At::ArrayOfTables(aar) => {
+                let index = key
+                    .parse::<usize>()
+                    .map_err(|_| anyhow!("Key is not a valid usize"))?;
+                let member = aar.get_mut(index).ok_or(anyhow!("Array out of range"))?;
+                do_traverse(path, &mut At::Table(member), op)
+            }
+            At::Item(item) => match item {
+                Item::ArrayOfTables(aar) => At::ArrayOfTables(aar).fold(key, path, op),
+                Item::Table(table) => At::Table(table).fold(key, path, op),
+                Item::Value(value) => At::Value(value).fold(key, path, op),
+                _ => Err(anyhow!("Unable to index item {:?} with {:?}", item, key)),
+            },
+            At::Table(table) => {
+                let mut found = table
+                    .get_mut(key)
+                    .ok_or(anyhow!("Unable to index table with {:?}", key))?;
+                do_traverse(path, &mut At::Item(&mut found), op)
+            }
+            At::Value(value) => match value {
+                Value::Array(arr) => At::Array(arr).fold(key, path, op),
+                _ => Err(anyhow!("Unable to index value {:?} with {:?}", value, key)),
+            },
+        }
+    }
+
+    pub fn to_value(&mut self) -> Result<serde_json::Value> {
+        match self {
+            At::Array(_arr) => Err(anyhow!("array")),
+            At::ArrayOfTables(_aar) => Err(anyhow!("stub")),
+            At::Item(item) => match item {
+                Item::None => Ok(Json::Null),
+                Item::Value(value) => At::Value(value).to_value(),
+                Item::ArrayOfTables(aar) => At::ArrayOfTables(aar).to_value(),
+                Item::Table(table) => At::Table(table).to_value(),
+            },
+            At::Value(value) => match value {
+                Value::String(s) => {
+                    s.fmt();
+                    Ok(Json::String(s.value().clone()))
+                }
+                Value::Integer(i) => Ok(Json::Number(serde_json::Number::from(
+                    i.clone().into_value(),
+                ))),
+                Value::Float(f) => {
+                    let n = serde_json::Number::from_f64(f.clone().into_value()).ok_or(anyhow!(
+                        "Unable to parse float as JSON: infinite and NaN are not allowed"
+                    ))?;
+                    Ok(Json::Number(n))
+                }
+                Value::Boolean(b) => Ok(Json::Bool(b.clone().into_value())),
+                Value::Array(arr) => {
+                    let xs = arr
+                        .iter_mut()
+                        .map(|val| At::Value(val).to_value())
+                        .collect::<Result<Vec<Json>>>()?;
+                    Ok(Json::Array(xs))
+                }
+                Value::Datetime(dt) => Ok(Json::String(dt.to_string())),
+                Value::InlineTable(table) => {
+                    let inner: Map<String, Json> = table
+                        .iter_mut()
+                        .map(|(k, v)| At::Value(v).to_value().map(|v| (k.to_string(), v)))
+                        .collect::<Result<Map<String, Json>>>()?;
+                    Ok(Json::Object(inner))
+                }
+            },
+            At::Table(table) => {
+                let inner: Map<String, Json> = table
+                    .iter_mut()
+                    .map(|(k, i)| At::Item(i).to_value().map(|v| (k.to_string(), v)))
+                    .collect::<Result<Map<String, Json>>>()?;
+                Ok(Json::Object(inner))
+            }
+        }
+    }
 }

--- a/src/traversal.rs
+++ b/src/traversal.rs
@@ -1,0 +1,24 @@
+use anyhow::{anyhow, Result};
+use serde_json::Value as Json;
+use toml_edit::{DocumentMut, Item};
+
+pub enum TraverseOps {
+    Get(Box<dyn FnOnce(serde_json::Value) -> ()>),
+}
+
+pub fn traverse(field: &str, doc: &mut DocumentMut, op: TraverseOps) -> Result<Json> {
+    let path_split = field
+        .split('/')
+        .map(|s| s.to_string())
+        .collect::<Vec<String>>();
+    let root_key = path_split.get(0).ok_or(anyhow!("Invalid query path!"))?;
+    let table = doc.as_table_mut();
+    let item = table
+        .get_mut(root_key)
+        .ok_or(anyhow!("Missing table for traversal"))?;
+    do_traverse(path_split, item, op)
+}
+
+fn do_traverse(mut path: Vec<String>, item: &mut Item, op: TraverseOps) -> Result<Json> {
+    Ok(Json::Null)
+}

--- a/src/traversal.rs
+++ b/src/traversal.rs
@@ -25,7 +25,7 @@ value:           Representation of a TOML Value (as part of a Key/Value Pair).
 
 */
 
-pub fn traverse<'a>(field: &str, doc: &'a mut DocumentMut, op: TraverseOps) -> Result<Json> {
+pub fn traverse<'a>(op: TraverseOps, doc: &'a mut DocumentMut, field: &str) -> Result<Json> {
     let path_split = field.split('/').collect::<Vec<&str>>();
     let path_slice = path_split.as_slice();
     let root_key = path_split.get(0).ok_or(anyhow!("Invalid query path!"))?;


### PR DESCRIPTION
Define a new `"get"` operation:

```shell
~/toml-editor$ echo '[{"op":"get", "path": "deployment/run/2"}, {"op":"get", "path": "nix/channel"} ]' \
             | cargo run \
             | jq .results
[
  "cargo check",
  "stable-23_11"
]
```

This will let us write stable queries against replspace files.

---

This also defines a new pattern, `traversal.rs`, which I intend to migrate the existing `add` and `remove` operations to, with the intent of reducing duplication.