### PR TITLE
bug/Fix flake, add gha tests

### DIFF
--- a/.github/workflows/nix-github-actions.yml
+++ b/.github/workflows/nix-github-actions.yml
@@ -1,0 +1,33 @@
+name: Nix Flake actions
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  nix-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v24
+      - id: set-matrix
+        name: Generate Nix Matrix
+        run: |
+          set -Eeu
+          matrix="$(nix eval --json '.#githubActions.matrix')"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  nix-build:
+    needs: nix-matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix: ${{fromJSON(needs.nix-matrix.outputs.matrix)}}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v24
+      - run: nix build -L ".#${{ matrix.attr }}"

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1656401090,
-        "narHash": "sha256-bUS2nfQsvTQW2z8SK7oEFSElbmoBahOPtbXPm0AL3I4=",
+        "lastModified": 1711593151,
+        "narHash": "sha256-/9NCoPI7fqJIN8viONsY9X0fAeq8jc3GslFCO0ky6TQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "16de63fcc54e88b9a106a603038dd5dd2feb21eb",
+        "rev": "bb2b73df7bcfbd2dd55ff39b944d70547d53c267",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,10 +2,13 @@
   description = "A toml editor that preserves formatting.";
 
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  inputs.nix-github-actions.url = "github:nix-community/nix-github-actions";
+  inputs.nix-github-actions.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs = {
     self,
     nixpkgs,
+    nix-github-actions,
   }: let
     systems = [
       "aarch64-darwin"
@@ -30,5 +33,8 @@
       fmt = pkgs.callPackage ./nix/fmt {};
     });
     formatter = eachSystem (system: self.packages.${system}.fmt);
+    githubActions = nix-github-actions.lib.mkGithubMatrix {
+      checks = nixpkgs.lib.getAttrs [ "x86_64-linux" ] self.packages;
+    };
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -33,8 +33,9 @@
       fmt = pkgs.callPackage ./nix/fmt {};
     });
     formatter = eachSystem (system: self.packages.${system}.fmt);
+    checks.x86_64-linux.default = self.packages.x86_64-linux.toml-editor;
     githubActions = nix-github-actions.lib.mkGithubMatrix {
-      checks = nixpkgs.lib.getAttrs [ "x86_64-linux" ] self.packages;
+      checks = nixpkgs.lib.getAttrs [ "x86_64-linux" ] self.checks;
     };
   };
 }


### PR DESCRIPTION
Turns out that the flake provided an old and incompatible version of `cargo`/`rustc`.

Fix this by bumping `nixpkgs`, as well as add GHA tests based on `nix-github-actions`.