### PR TITLE
feat: support for appending to array at path

### DIFF
--- a/src/adder.rs
+++ b/src/adder.rs
@@ -19,7 +19,7 @@ pub fn handle_add(doc: &mut DocumentMut, op: AddOp) -> Result<()> {
                 .split('/')
                 .map(|s| s.to_string())
                 .collect::<Vec<String>>();
-            let dotted_path_vec =
+            let mut dotted_path_vec =
                 path.map(|p| p.split('/').map(|s| s.to_string()).collect::<Vec<String>>());
             let field_value_json: JValue =
                 from_str(&value).context("parsing value field in add request")?;
@@ -35,12 +35,20 @@ pub fn handle_add(doc: &mut DocumentMut, op: AddOp) -> Result<()> {
             } else {
                 false
             };
+            let append_array_at_path = match &mut dotted_path_vec {
+                Some(path_vec) if path_vec.last().is_some_and(|key| key == "[]") => {
+                    path_vec.pop();
+                    true
+                }
+                _ => false,
+            };
             table_header_adder::add_value_with_table_header_and_dotted_path(
                 doc,
                 &table_header_path_vec,
                 dotted_path_vec,
                 field_value_toml,
                 array_of_tables,
+                append_array_at_path,
             )
         }
         None => {
@@ -177,7 +185,16 @@ test = "yo"
         none = "all""#;
 
     macro_rules! meta_add_test {
-        ($name:ident, $table_header_path:expr, $field:expr, $value:expr, $contents:expr, $expected:expr, $result:ident, $($assertion:stmt)*) => {
+        (
+            $name:ident,
+            $table_header_path:expr,
+            $field:expr,
+            $value:expr,
+            $contents:expr,
+            $expected:expr,
+            $result:ident,
+            $($assertion:stmt)*
+        ) => {
             #[test]
             fn $name() {
                 let mut doc = $contents.parse::<DocumentMut>().unwrap();
@@ -672,6 +689,70 @@ key = "second"
         r#"
 [tool.uv.sources]
 torchvision = [{ index = "pytorch-cpu", marker = "platform_system == 'Linux'" }]
+        "#
+    );
+
+    add_table_header_test!(
+        test_append_array_at_path_empty,
+        Some("tool/uv/sources"),
+        Some("torch/[]"),
+        r#"
+        {"index": "pytorch-cpu", "marker": "platform_system == 'Linux'"}
+        "#,
+        r#"
+        "#,
+        r#"
+[tool.uv.sources]
+torch = [{ index = "pytorch-cpu", marker = "platform_system == 'Linux'" }]
+        "#
+    );
+
+    add_table_header_test!(
+        test_append_array_at_path_empty_dotted_path,
+        Some("tool/uv/sources"),
+        Some("torch/test/[]"),
+        r#"
+        {"index": "pytorch-cpu", "marker": "platform_system == 'Linux'"}
+        "#,
+        r#"
+        "#,
+        r#"
+[tool.uv.sources]
+torch.test = [{ index = "pytorch-cpu", marker = "platform_system == 'Linux'" }]
+        "#
+    );
+
+    add_table_header_test!(
+        test_append_array_at_path_existing,
+        Some("tool/uv/sources"),
+        Some("torch/[]"),
+        r#"
+        {"index": "pytorch-cpu", "marker": "platform_system == 'Linux'"}
+        "#,
+        r#"
+[tool.uv.sources]
+torch = [{ index = "foo", marker = "platform_system == 'Windows'" }]
+        "#,
+        r#"
+[tool.uv.sources]
+torch = [{ index = "foo", marker = "platform_system == 'Windows'" }, { index = "pytorch-cpu", marker = "platform_system == 'Linux'" }]
+        "#
+    );
+
+    add_table_header_error_test!(
+        test_append_array_at_path_existing_non_array_at_path,
+        Some("tool/uv/sources"),
+        Some("torch/[]"),
+        r#"
+        {"index": "pytorch-cpu", "marker": "platform_system == 'Linux'"}
+        "#,
+        r#"
+[tool.uv.sources]
+torch = 1
+        "#,
+        r#"
+[tool.uv.sources]
+torch = 1
         "#
     );
 }

--- a/src/adder.rs
+++ b/src/adder.rs
@@ -188,9 +188,9 @@ test = "yo"
 
                 let op = AddOp {
                     path: field,
-                    table_header_path: table_header_path,
+                    table_header_path,
                     dotted_path: None,
-                    value: value,
+                    value,
                 };
                 let $result = handle_add(&mut doc, op);
                 $(

--- a/src/adder/table_header_adder.rs
+++ b/src/adder/table_header_adder.rs
@@ -20,7 +20,7 @@ pub fn add_value_with_table_header_and_dotted_path(
     value: Item,
     array_of_tables: bool,
 ) -> Result<()> {
-    match table_header_path.get(0) {
+    match table_header_path.first() {
         None => {
             add_value_with_dotted_path(
                 table,
@@ -108,16 +108,16 @@ fn add_value_with_dotted_path(
     dotted_path: &[String],
     value: Item,
 ) -> Result<()> {
-    match dotted_path.get(0) {
+    match dotted_path.first() {
         None => Ok(()),
         Some(field) => match table.get_mut(field) {
             None | Some(Item::None) => {
                 if dotted_path.len() > 1 {
                     let mut inner_table = Table::new();
                     inner_table.set_dotted(true);
-                    return add_value_with_dotted_path(&mut inner_table, &dotted_path[1..], value)
+                    add_value_with_dotted_path(&mut inner_table, &dotted_path[1..], value)
                         .map(|_| table.insert(field, Item::Table(inner_table)))
-                        .map(|_| ());
+                        .map(|_| ())
                 } else {
                     table.insert(field, value);
                     Ok(())
@@ -126,7 +126,7 @@ fn add_value_with_dotted_path(
             Some(Item::Table(ref mut inner_table)) => {
                 if dotted_path.len() > 1 {
                     inner_table.set_dotted(true);
-                    return add_value_with_dotted_path(inner_table, &dotted_path[1..], value);
+                    add_value_with_dotted_path(inner_table, &dotted_path[1..], value)
                 } else {
                     table.insert(field, value);
                     Ok(())

--- a/src/adder/table_header_adder.rs
+++ b/src/adder/table_header_adder.rs
@@ -115,9 +115,9 @@ fn add_value_with_dotted_path(
                 if dotted_path.len() > 1 {
                     let mut inner_table = Table::new();
                     inner_table.set_dotted(true);
-                    add_value_with_dotted_path(&mut inner_table, &dotted_path[1..], value)
-                        .map(|_| table.insert(field, Item::Table(inner_table)))
-                        .map(|_| ())
+                    add_value_with_dotted_path(&mut inner_table, &dotted_path[1..], value)?;
+                    table.insert(field, Item::Table(inner_table));
+                    Ok(())
                 } else {
                     table.insert(field, value);
                     Ok(())

--- a/src/field_finder.rs
+++ b/src/field_finder.rs
@@ -34,7 +34,7 @@ fn descend_table<'a>(
     do_insert: DoInsert,
     last_field: &String,
 ) -> Result<TomlValue<'a>> {
-    let segment = match path.get(0) {
+    let segment = match path.first() {
         Some(segment) => segment,
         None => return Ok(TomlValue::Table(table)),
     };
@@ -103,7 +103,7 @@ fn descend_array_of_tables<'a>(
     do_insert: DoInsert,
     last_field: &String,
 ) -> Result<TomlValue<'a>> {
-    let segment = match path.get(0) {
+    let segment = match path.first() {
         Some(segment) => segment,
         None => return Ok(TomlValue::ArrayOfTables(array)),
     };
@@ -143,7 +143,7 @@ fn descend_inline_table<'a>(
     do_insert: DoInsert,
     last_field: &String,
 ) -> Result<TomlValue<'a>> {
-    let segment = match path.get(0) {
+    let segment = match path.first() {
         Some(segment) => segment,
         None => return Ok(TomlValue::InlineTable(inline_table)),
     };
@@ -165,7 +165,7 @@ fn descend_array<'a>(
     do_insert: DoInsert,
     last_field: &String,
 ) -> Result<TomlValue<'a>> {
-    let segment = match path.get(0) {
+    let segment = match path.first() {
         Some(segment) => segment,
         None => return Ok(TomlValue::Array(array)),
     };
@@ -205,7 +205,7 @@ bla = "bla"
 
         let mut doc = doc_string.parse::<DocumentMut>().unwrap();
         let val = get_field(
-            &(vec!["foo".to_string()]),
+            &["foo".to_string()],
             &"bar".to_string(),
             DoInsert::Yes,
             &mut doc,

--- a/src/field_finder.rs
+++ b/src/field_finder.rs
@@ -19,7 +19,7 @@ pub enum DoInsert {
 
 pub fn get_field<'a>(
     path: &[String],
-    last_field: &String,
+    last_field: &str,
     do_insert: DoInsert,
     doc: &'a mut DocumentMut,
 ) -> Result<TomlValue<'a>> {
@@ -32,7 +32,7 @@ fn descend_table<'a>(
     table: &'a mut Table,
     path: &[String],
     do_insert: DoInsert,
-    last_field: &String,
+    last_field: &str,
 ) -> Result<TomlValue<'a>> {
     let segment = match path.first() {
         Some(segment) => segment,
@@ -67,7 +67,7 @@ fn descend_item<'a>(
     item: &'a mut Item,
     path: &[String],
     do_insert: DoInsert,
-    last_field: &String,
+    last_field: &str,
 ) -> Result<TomlValue<'a>> {
     match item {
         Item::Table(table) => descend_table(table, path, do_insert, last_field),
@@ -81,7 +81,7 @@ fn descend_value<'a>(
     value: &'a mut Value,
     path: &[String],
     do_insert: DoInsert,
-    last_field: &String,
+    last_field: &str,
 ) -> Result<TomlValue<'a>> {
     match value {
         Value::Array(array) => descend_array(array, path, do_insert, last_field),
@@ -101,7 +101,7 @@ fn descend_array_of_tables<'a>(
     array: &'a mut ArrayOfTables,
     path: &[String],
     do_insert: DoInsert,
-    last_field: &String,
+    last_field: &str,
 ) -> Result<TomlValue<'a>> {
     let segment = match path.first() {
         Some(segment) => segment,
@@ -141,7 +141,7 @@ fn descend_inline_table<'a>(
     inline_table: &'a mut InlineTable,
     path: &[String],
     do_insert: DoInsert,
-    last_field: &String,
+    last_field: &str,
 ) -> Result<TomlValue<'a>> {
     let segment = match path.first() {
         Some(segment) => segment,
@@ -163,7 +163,7 @@ fn descend_array<'a>(
     array: &'a mut Array,
     path: &[String],
     do_insert: DoInsert,
-    last_field: &String,
+    last_field: &str,
 ) -> Result<TomlValue<'a>> {
     let segment = match path.first() {
         Some(segment) => segment,
@@ -206,7 +206,7 @@ bla = "bla"
         let mut doc = doc_string.parse::<DocumentMut>().unwrap();
         let val = get_field(
             &["foo".to_string()],
-            &"bar".to_string(),
+            "bar",
             DoInsert::Yes,
             &mut doc,
         )
@@ -224,7 +224,7 @@ bla = "bla"
         let doc_string = r#"test = [ 1 ]"#;
         let mut doc = doc_string.parse::<DocumentMut>().unwrap();
         let fields = ["test".to_string()];
-        let val = get_field(&(fields), &"1".to_string(), DoInsert::Yes, &mut doc).unwrap();
+        let val = get_field(&(fields), "1", DoInsert::Yes, &mut doc).unwrap();
 
         if let TomlValue::Array(array) = val {
             assert_eq!(array.len(), 1);
@@ -243,7 +243,7 @@ foo = "baz"
 "#;
         let mut doc = doc_string.parse::<DocumentMut>().unwrap();
         let fields = ["test".to_string()];
-        let val = get_field(&(fields), &"2".to_string(), DoInsert::Yes, &mut doc).unwrap();
+        let val = get_field(&(fields), "2", DoInsert::Yes, &mut doc).unwrap();
 
         if let TomlValue::ArrayOfTables(array) = val {
             assert_eq!(array.len(), 2);

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ fn do_edits(
 
     // we need to re-read the file each time since the user might manually edit the
     // file and so we need to make sure we have the most up to date version.
-    let dotreplit_contents = match fs::read_to_string(&dotreplit_filepath) {
+    let dotreplit_contents = match fs::read_to_string(dotreplit_filepath) {
         Ok(contents) => contents,
         Err(err) if err.kind() == io::ErrorKind::NotFound => "".to_string(), // if .replit doesn't exist start with an empty one
         Err(_) => return Err(anyhow!("error: reading file - {:?}", &dotreplit_filepath)),
@@ -146,7 +146,7 @@ fn do_edits(
 
     // write the file back to disk
     if changed {
-        fs::write(&dotreplit_filepath, doc.to_string())
+        fs::write(dotreplit_filepath, doc.to_string())
             .with_context(|| format!("error: writing file: {:?}", &dotreplit_filepath))?;
     }
     Ok(("".to_string(), outputs))

--- a/src/traversal.rs
+++ b/src/traversal.rs
@@ -53,7 +53,7 @@ pub fn traverse<'a>(
     }
 
     match op {
-        TraverseOps::Get => result?.to_value().map(|v| Some(v)),
+        TraverseOps::Get => result?.to_value().map(Some),
     }
 }
 


### PR DESCRIPTION
- add `/[]` syntax to path that will append instead of overwriting the value at the path

For example, if we have a `pyproject.toml` with the following contents:

```toml
[tool.uv.sources]
torch = [{ index = "foo", marker = "platform_system == 'Windows'" }]
```

Then applying:

```console
jq -c -n '[{op: "add", table_header_path: "tool/uv/sources", path: "torch/[]", value: "{\"index\": \"pytorch-cpu\"}"}]' | cargo run -- --path pyproject.toml
```

Will result in the following contents in `pyproject.toml`:

```toml
[tool.uv.sources]
torch = [{ index = "foo", marker = "platform_system == 'Windows'" }, { index = "pytorch-cpu" }]
```

- also fix some clippy lints