### PR TITLE
fix double copy

### DIFF
--- a/toml-editor.nix
+++ b/toml-editor.nix
@@ -10,5 +10,9 @@ rustPlatform.buildRustPackage {
     lockFile = ./Cargo.lock;
   };
 
-  src = ./.;
+  src = builtins.path {
+    path = ./.;
+    name = "source";
+  };
+
 }


### PR DESCRIPTION
Why
===
* New lazy trees nix warns about double copies from using ./.

What changed
===
* Replace with recommended replacement

Test plan
===
* `nix build` works