### PR TITLE
dont edit file if contents haven't changed

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -116,12 +116,10 @@ fn do_edits(
         .parse::<DocumentMut>()
         .with_context(|| format!("error: parsing file - {:?}", &dotreplit_filepath))?;
 
-    let mut changed: bool = false;
     let mut outputs: Vec<Value> = vec![];
     for op in json {
         match op {
             OpKind::Add(op) => {
-                changed = true;
                 handle_add(&mut doc, op)?;
                 outputs.push(json!("ok"));
             }
@@ -133,7 +131,6 @@ fn do_edits(
                 }
             },
             OpKind::Remove { path } => {
-                changed = true;
                 handle_remove(&path, &mut doc)?;
                 outputs.push(json!("ok"));
             }
@@ -145,8 +142,9 @@ fn do_edits(
     }
 
     // write the file back to disk
-    if changed {
-        fs::write(dotreplit_filepath, doc.to_string())
+    let new_contents = doc.to_string();
+    if dotreplit_contents != new_contents {
+        fs::write(dotreplit_filepath, new_contents)
             .with_context(|| format!("error: writing file: {:?}", &dotreplit_filepath))?;
     }
     Ok(("".to_string(), outputs))


### PR DESCRIPTION
Why
===
* editing .replit causes other things to recompute, let's not edit it if we didn't change it

What changed
===
* check strings are different before writing to file

Test plan
===
* ran it and sent `[ { "op": "add", "path": "foo", "value": "123" }]` multiple times and saw it only changed the first time